### PR TITLE
add toggle protection mode with one page scope

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -19,3 +19,83 @@ h1 {
 #content {
   width: 100%;
 }
+
+.site-info {
+  background-color: #f0f0f0;
+  padding: 8px;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+.current-url {
+  font-size: 14px;
+  color: #666;
+  word-break: break-all;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  margin: 10px 0;
+}
+
+.toggle-label {
+  font-size: 16px;
+  color: #333;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:checked + .slider:before {
+  transform: translateX(26px);
+}
+
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,4 +1,28 @@
 document.addEventListener('DOMContentLoaded', function() {
-  // Votre code JavaScript ira ici
-  console.log('Extension Mockify chargée !');
+  const protectionToggle = document.getElementById('protectionToggle');
+  const urlDisplay = document.getElementById('currentUrl');
+
+  // Obtenir l'onglet actif
+  chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+    const currentTab = tabs[0];
+    const hostname = new URL(currentTab.url).hostname;
+    urlDisplay.textContent = hostname;
+
+    // Charger l'état sauvegardé du toggle pour ce site
+    const storageKey = `protectionMode_${hostname}`;
+    chrome.storage.local.get([storageKey], function(result) {
+      protectionToggle.checked = result[storageKey] || false;
+    });
+
+    // Sauvegarder l'état du toggle quand il change
+    protectionToggle.addEventListener('change', function() {
+      const isEnabled = this.checked;
+      const saveData = {};
+      saveData[storageKey] = isEnabled;
+      
+      chrome.storage.local.set(saveData, function() {
+        console.log(`Mode protection ${isEnabled ? 'activé' : 'désactivé'} pour ${hostname}`);
+      });
+    });
+  });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mockify",
   "version": "1.0",
   "description": "Une extension Chrome pour Mockify",
-  "permissions": [],
+  "permissions": ["storage", "tabs", "activeTab"],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/popup.html
+++ b/popup.html
@@ -9,7 +9,16 @@
   <div id="app">
     <h1>Mockify</h1>
     <div id="content">
-      <!-- Le contenu de votre extension ira ici -->
+      <div class="site-info">
+        <span id="currentUrl" class="current-url"></span>
+      </div>
+      <div class="toggle-container">
+        <label class="toggle-label">Mode Protection</label>
+        <label class="switch">
+          <input type="checkbox" id="protectionToggle">
+          <span class="slider round"></span>
+        </label>
+      </div>
     </div>
   </div>
   <script src="js/popup.js"></script>


### PR DESCRIPTION
Cette PR ajoute un mode de protection configurable par site :
     
     - Ajout d'un toggle dans la popup pour activer/désactiver le mode protection
     - Le mode protection est spécifique à chaque site (basé sur le hostname)
     - Affichage du site actuel dans l'interface
     - Stockage local des préférences par site
     
     Changements techniques :
     - Utilisation de chrome.storage.local pour le stockage
     - Ajout des permissions tabs et activeTab
     - Nouvelle interface utilisateur avec affichage du site actuel